### PR TITLE
making command and args conditional

### DIFF
--- a/charts/application/templates/deployment.yaml
+++ b/charts/application/templates/deployment.yaml
@@ -36,13 +36,13 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: Always
-          {{- with .Values.command }}
+          {{ if .Values.entrypoint }}
           command:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.entrypoint | nindent 12 }}
           {{- end }}
-          {{- with .Values.args }}
+          {{- if .Values.cmd }}
           args:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.cmd | nindent 12 }}
           {{- end }}
           {{- with .Values.envs }}
           env:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -2,11 +2,15 @@ image:
   repository:
   tag:
 
-command: []
-args: []
+# k8s uses 'command' but Docker images call this ENTRYPOINT
+# k8s uses 'args' but Docker images call this CMD
+# both are commented out so the
+# container ENTRYPOINT / CMD is used by default
+# entrypoint: []
+# cmd: []
 
 envs: []
-port: 
+port:
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
- I made these conditional so we don't override the ones in the container by default.
- I'm also proposing a change to the name of the variables we expose, to align more with what a Docker dev is familiar with.

The default, w/o specifying them.

```
---
# Source: application/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app.kubernetes.io/name: test
    app.kubernetes.io/managed-by: massdriver.cloud
spec:
  replicas:
  selector:
    matchLabels:
      app.kubernetes.io/name: test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: test
    spec:
      serviceAccountName: test
      containers:
        - name: test
          image: ":"
          imagePullPolicy: Always

          resources:
```

Just using these as an example, `rails server` would most likely just be one or the other of these.

```yaml
entrypoint: ["rails"]
cmd: ["server"]
```

```
# Source: application/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app.kubernetes.io/name: test
    app.kubernetes.io/managed-by: massdriver.cloud
spec:
  replicas:
  selector:
    matchLabels:
      app.kubernetes.io/name: test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: test
    spec:
      serviceAccountName: test
      containers:
        - name: test
          image: ":"
          imagePullPolicy: Always

          command:
            - rails
          args:
            - server
          resources:
```