### PR TITLE
making env vars conditional

### DIFF
--- a/charts/application/templates/deployment.yaml
+++ b/charts/application/templates/deployment.yaml
@@ -44,9 +44,9 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.envs }}
+          {{- if .Values.envs }}
           env:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.envs | nindent 12 }}
           {{- end }}
           {{- if .Values.port }}
           ports:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -5,8 +5,10 @@ image:
 command: []
 args: []
 
-envs: []
-port: 
+# specify your environment variables!
+# default this is commented-out in case you don't have any
+# envs: []
+port:
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
It will be rare, but some applications don't need user-supplied env-vars. This makes envs conditional. 