### PR TITLE
remove smtp hostname and bump image version

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.8
-appVersion: 1.0.8
+version: 0.0.9
+appVersion: 1.0.9
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -33,8 +33,7 @@ data:
 {{- end }}
   RELEASE_COOKIE: {{ include "massdriver.releaseCookie" . | b64enc | quote }}
   SMTP_FROM_ADDRESS: {{ .Values.smtp.fromAddress | b64enc | quote }}
-  SMTP_HOSTNAME: {{ .Values.smtp.hostname | b64enc | quote }}
-  SMTP_PASSWORD: {{ .Values.smtp.password  | b64enc | quote }}
-  SMTP_PORT: {{ .Values.smtp.port | toString  | b64enc | quote }}
-  SMTP_SERVER: {{ .Values.smtp.server  | b64enc | quote }}
-  SMTP_USERNAME: {{ .Values.smtp.username  | b64enc | quote }}
+  SMTP_PASSWORD: {{ .Values.smtp.password | b64enc | quote }}
+  SMTP_PORT: {{ .Values.smtp.port | toString | b64enc | quote }}
+  SMTP_SERVER: {{ .Values.smtp.server | b64enc | quote }}
+  SMTP_USERNAME: {{ .Values.smtp.username | b64enc | quote }}

--- a/charts/massdriver/values-example.yaml
+++ b/charts/massdriver/values-example.yaml
@@ -12,7 +12,6 @@ postgres:
 smtp:
   username: 
   password: 
-  hostname:    # eg. your-domain.com
   server:      # eg. email.some-smtp-provider.com
   port: 587
   fromAddress: # eg. no-reply@your-domain.com

--- a/charts/massdriver/values.schema.json
+++ b/charts/massdriver/values.schema.json
@@ -90,12 +90,8 @@
     "smtp": {
       "type": "object",
       "description": "SMTP server configuration for sending emails",
-      "required": ["hostname", "server", "port", "username", "password", "fromAddress"],
+      "required": ["server", "port", "username", "password", "fromAddress"],
       "properties": {
-        "hostname": {
-          "type": "string",
-          "minLength": 1
-        },
         "port": {
             "type": "integer",
             "minimum": 1,

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -9,7 +9,6 @@ postgres:
 smtp:
   username: 
   password: 
-  hostname:    # eg. your-domain.com
   server:      # eg. email.some-smtp-provider.com
   port: 587
   fromAddress: # eg. no-reply@your-domain.com
@@ -60,7 +59,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.0.8"
+    tag: "1.0.9"
 
   port: 4000
 


### PR DESCRIPTION
Remove the unnecessary `smtp.hostname` value and corresponding environment variable.