### PR TITLE
Bug fixes, patches, and extra configuration options

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: 1.0.9
 
 dependencies:

--- a/charts/massdriver/templates/launch-control/deployment.yaml
+++ b/charts/massdriver/templates/launch-control/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       app.kubernetes.io/component: launch-control
   template:
     metadata:
-      {{- with .Values.launchControl.podAnnotations }}
       annotations:
+        configmap.launch-control-envs/checksum: {{ include (print $.Template.BasePath "/launch-control/configmap-envs.yaml") . | sha256sum }}
+        {{- with .Values.launchControl.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "massdriver.labels" . | nindent 8 }}
         {{- with .Values.launchControl.podLabels }}

--- a/charts/massdriver/templates/massdriver/configmap-envs.yaml
+++ b/charts/massdriver/templates/massdriver/configmap-envs.yaml
@@ -20,16 +20,18 @@ data:
   FORCE_V2_LOGGING: "true"
   LOG_LEVEL: {{ .Values.massdriver.logLevel | quote }}
   MD_DEPLOYMENT_QUEUE_API_URL: "http://{{ include "massdriver.fullname" . }}-launch-control.{{ .Release.Namespace }}.svc:{{ toString .Values.launchControl.service.port }}"
+  {{- if .Values.massdriver.epmd.enabled }}
   MD_EPMD_CLUSTER_SERVICE: {{ include "massdriver.fullname" . }}-massdriver-epmd.{{ .Release.Namespace }}.svc
-  MD_FRONTEND_URL: {{ include "massdriver.protocol" . }}://app.{{ .Values.domain }}
+  {{- end }}
+  MD_FRONTEND_URL: {{ include "massdriver.protocol" . }}://{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
   MD_REPOSITORY_BUCKET: {{ .Values.massdriver.blobStorage.massdriverBucket }}
   MIX_ENV: prod
   OTEL_RESOURCE_ATTRIBUTES: service.name=massdriver
-  PHX_CHECK_ORIGIN: //api.{{ .Values.domain }},//app.{{ .Values.domain }}
-  PHX_CORS_ORIGINS: {{ include "massdriver.protocol" . }}://www.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://api.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://app.{{ .Values.domain }}
+  PHX_CHECK_ORIGIN: //{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},//{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
+  PHX_CORS_ORIGINS: {{ include "massdriver.protocol" . }}://www.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
   PHX_HTTP_PORT: {{ .Values.massdriver.port | toString | quote }}
   PHX_SERVER: "true"
-  PHX_URL_HOST: api.{{ .Values.domain }}
+  PHX_URL_HOST: {{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}
   PHX_URL_PORT: "{{ if .Values.massdriver.ingress.tls.enabled }}443{{ else }}80{{ end }}"
   PHX_URL_SCHEME: {{ include "massdriver.protocol" . }}
   TERRAFORM_STATE_BUCKET_NAME: {{ .Values.massdriver.blobStorage.stateBucket }}

--- a/charts/massdriver/templates/massdriver/configmap-ui.yaml
+++ b/charts/massdriver/templates/massdriver/configmap-ui.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata: 
-  name: {{ include "massdriver.fullname" . }}-ui
+  name: {{ include "massdriver.fullname" . }}-ui-envs
   labels:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: ui
 data:
   env: |-
-    NEXT_PUBLIC_MASSDRIVER_URL={{ include "massdriver.protocol" . }}://api.{{ .Values.domain }}
-    NEXT_PUBLIC_MASSDRIVER_WS_URL={{ include "massdriver.websocketProtocol" . }}://api.{{ .Values.domain }}
+    NEXT_PUBLIC_MASSDRIVER_URL={{ include "massdriver.protocol" . }}://{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}
+    NEXT_PUBLIC_MASSDRIVER_WS_URL={{ include "massdriver.websocketProtocol" . }}://{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}

--- a/charts/massdriver/templates/massdriver/deployment.yaml
+++ b/charts/massdriver/templates/massdriver/deployment.yaml
@@ -13,10 +13,14 @@ spec:
       app.kubernetes.io/component: massdriver
   template:
     metadata:
-      {{- with .Values.massdriver.podAnnotations }}
       annotations:
+      {{- with .Values.massdriver.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        configmap.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-envs.yaml") . | sha256sum }}
+        configmap.ui-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-ui.yaml") . | sha256sum }}
+        secret.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/secret-envs.yaml") . | sha256sum }}
+        secret.minio/checksum: {{ include (print $.Template.BasePath "/massdriver/secret-minio.yaml") . | sha256sum }}
       labels:
         {{- include "massdriver.labels" . | nindent 8 }}
         {{- with .Values.massdriver.podLabels }}
@@ -98,13 +102,13 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: ui
+            - name: ui-envs
               mountPath: /app/.env
               subPath: env
       volumes:
-        - name: ui
+        - name: ui-envs
           configMap:
-            name: {{ include "massdriver.fullname" . }}-ui
+            name: {{ include "massdriver.fullname" . }}-ui-envs
       {{- with .Values.massdriver.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/massdriver/templates/massdriver/deployment.yaml
+++ b/charts/massdriver/templates/massdriver/deployment.yaml
@@ -14,9 +14,9 @@ spec:
   template:
     metadata:
       annotations:
-      {{- with .Values.massdriver.podAnnotations }}
+        {{- with .Values.massdriver.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
         configmap.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-envs.yaml") . | sha256sum }}
         configmap.ui-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-ui.yaml") . | sha256sum }}
         secret.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/secret-envs.yaml") . | sha256sum }}

--- a/charts/massdriver/templates/massdriver/ingress.yaml
+++ b/charts/massdriver/templates/massdriver/ingress.yaml
@@ -17,12 +17,12 @@ spec:
   {{- if .Values.massdriver.ingress.tls.enabled }}
   tls:
     - hosts:
-        - api.{{ .Values.domain }}
-        - app.{{ .Values.domain }}
+        - {{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}
+        - {{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
       secretName: {{ include "massdriver.tlsSecretName" . }}
   {{- end }}
   rules:
-    - host: api.{{ .Values.domain }}
+    - host: {{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}
       http:
         paths:
           - path: /
@@ -32,7 +32,7 @@ spec:
                 name: {{ include "massdriver.fullname" . }}-massdriver
                 port:
                   name: http
-    - host: app.{{ .Values.domain }}
+    - host: {{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
       http:
         paths:
           - path: /

--- a/charts/massdriver/templates/massdriver/job-db-migration.yaml
+++ b/charts/massdriver/templates/massdriver/job-db-migration.yaml
@@ -44,4 +44,16 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.massdriver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.massdriver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.massdriver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -23,7 +23,7 @@ data:
   {{- end }}
   PHX_SECRET_KEY_BASE: {{ include "massdriver.phxSecretKeyBase" . | b64enc | quote }}
   PHX_SIGNING_SALT: {{ include "massdriver.phxSigningSalt" . | b64enc | quote }}
-  POSTGRES_DATABASE: {{ printf "massdriver_prod" | b64enc | quote }}
+  POSTGRES_DATABASE: {{ .Values.postgres.database | b64enc | quote }}
   POSTGRES_HOSTNAME: {{ .Values.postgres.hostname | b64enc | quote }}
   POSTGRES_PASSWORD: {{ .Values.postgres.password | b64enc | quote }}
   POSTGRES_USERNAME: {{ .Values.postgres.username | b64enc | quote }}

--- a/charts/massdriver/templates/massdriver/service-epmd.yaml
+++ b/charts/massdriver/templates/massdriver/service-epmd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.massdriver.epmd.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -15,3 +16,4 @@ spec:
   selector:
     {{- include "massdriver.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: massdriver
+{{- end }}

--- a/charts/massdriver/values-example.yaml
+++ b/charts/massdriver/values-example.yaml
@@ -7,6 +7,7 @@ postgres:
   username: 
   password: 
   hostname: 
+  database: massdriver
   port: 5432
 
 smtp:

--- a/charts/massdriver/values.schema.json
+++ b/charts/massdriver/values.schema.json
@@ -66,7 +66,7 @@
     "postgres": {
       "type": "object",
       "description": "PostgreSQL database configuration",
-      "required": ["username", "password", "hostname", "port"],
+      "required": ["username", "password", "hostname", "database","port"],
       "properties": {
         "username": {
           "type": "string",
@@ -77,6 +77,10 @@
           "minLength": 1
         },
         "hostname": {
+          "type": "string",
+          "minLength": 1
+        },
+        "database": {
           "type": "string",
           "minLength": 1
         },

--- a/charts/massdriver/values.schema.json
+++ b/charts/massdriver/values.schema.json
@@ -66,7 +66,7 @@
     "postgres": {
       "type": "object",
       "description": "PostgreSQL database configuration",
-      "required": ["username", "password", "hostname", "database","port"],
+      "required": ["username", "password", "hostname", "database", "port"],
       "properties": {
         "username": {
           "type": "string",

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -4,6 +4,7 @@ postgres:
   username: 
   password: 
   hostname: 
+  database: massdriver
   port: 5432
 
 smtp:
@@ -33,6 +34,10 @@ fullnameOverride: ""
 # Massdriver Variables
 massdriver:
   logLevel: info
+
+  # The subdomains to use for Massdriver. These will be used to construct URLs for the frontend and API.
+  apiSubdomain: api
+  appSubdomain: app
 
   # Configuration for blob storage
   blobStorage:
@@ -138,6 +143,7 @@ massdriver:
       #   -----END RSA PRIVATE KEY-----
 
   epmd:
+    enabled: true
     port: 4369
 
   migration:


### PR DESCRIPTION
This PR implements bug fixes, patches, and adds extra configuration options to the Massdriver Helm chart. The changes enhance configurability and fix issues with resource naming and database configuration.

* Makes database name configurable instead of hardcoded
* Adds configurable subdomain support for API and frontend endpoints
* Fixes conditional EPMD service deployment 
* Adds annotations to auto-trigger pod cycling on configmap/secret changes