### PR TITLE
Massdriver 0.0.12

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.11
-appVersion: 1.0.10
+version: 0.0.12
+appVersion: 1.0.11
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.10
-appVersion: 1.0.9
+version: 0.0.11
+appVersion: 1.0.10
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -20,6 +20,9 @@ data:
   MD_OIDC__{{ $name }}__CLIENT_ID: {{ .clientId | b64enc | quote }}
   MD_OIDC__{{ $name }}__CLIENT_SECRET: {{ .clientSecret | b64enc | quote }}
   MD_OIDC__{{ $name }}__TOKEN_URL: {{ .tokenUrl | b64enc | quote }}
+  {{- if not (empty .autojoinOrganization) }}
+  MD_OIDC__{{ $name }}__AUTOJOIN_ORGANIZATION: {{ .autojoinOrganization | b64enc | quote }}
+  {{- end }}
   {{- end }}
   PHX_SECRET_KEY_BASE: {{ include "massdriver.phxSecretKeyBase" . | b64enc | quote }}
   PHX_SIGNING_SALT: {{ include "massdriver.phxSigningSalt" . | b64enc | quote }}

--- a/charts/massdriver/values-example.yaml
+++ b/charts/massdriver/values-example.yaml
@@ -40,6 +40,7 @@ oidc: []
   #   tokenUrl:
   #   clientId: 
   #   clientSecret: 
+  #   autojoinOrganization:  # The Massdriver organization to autojoin after OIDC authentication (optional)
 
 massdriver:
   ingress:

--- a/charts/massdriver/values.schema.json
+++ b/charts/massdriver/values.schema.json
@@ -59,6 +59,10 @@
             "type": "string",
             "minLength": 1,
             "description": "The client secret for the OIDC provider"
+          },
+          "autojoinOrganization": {
+            "type": "string",
+            "description": "The Massdriver organization to autojoin after OIDC authentication (optional)"
           }
         }
       }

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -64,7 +64,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.0.9"
+    tag: "1.0.10"
 
   port: 4000
 

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -64,7 +64,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.0.10"
+    tag: "1.0.11"
 
   port: 4000
 
@@ -73,8 +73,8 @@ massdriver:
       cpu: 1
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 300Mi
   
   livenessProbe: {}
     # httpGet:
@@ -164,11 +164,11 @@ launchControl:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 500m
+      memory: 250Mi
     requests:
       cpu: 50m
-      memory: 64Mi
+      memory: 50Mi
   
   livenessProbe: {}
     # httpGet:
@@ -225,7 +225,7 @@ ui:
   image:
     repository: massdrivercloud/massdriver-ui
     pullPolicy: IfNotPresent
-    tag: "1.0.6"
+    tag: "1.0.7"
 
   port: 3000
 
@@ -234,8 +234,8 @@ ui:
       cpu: 1
       memory: 1Gi
     requests:
-      cpu: 400m
-      memory: 512Mi
+      cpu: 100m
+      memory: 200Mi
   
   livenessProbe: {}
     # httpGet:
@@ -264,6 +264,7 @@ oidc: []
   #   tokenUrl:
   #   clientId: 
   #   clientSecret: 
+  #   autojoinOrganization:  # The Massdriver organization to autojoin after OIDC authentication (optional)
 
 
 # Extra manifests to deploy as an array of objects


### PR DESCRIPTION
This PR updates the Massdriver Helm chart to version 0.0.12, upgrading application versions and adjusting resource allocations.

* Updated chart version from 0.0.11 to 0.0.12 and app version from 1.0.10 to 1.0.11
* Adjusted CPU and memory resource allocations across multiple services
* Added optional autojoin organization feature for OIDC authentication