### PR TITLE
Upgrade massdriver image to 1.0.12

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.12
-appVersion: 1.0.11
+version: 0.0.13
+appVersion: 1.0.12
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -225,7 +225,7 @@ ui:
   image:
     repository: massdrivercloud/massdriver-ui
     pullPolicy: IfNotPresent
-    tag: "1.0.7"
+    tag: "1.0.8"
 
   port: 3000
 

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -64,7 +64,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.0.11"
+    tag: "1.0.12"
 
   port: 4000
 


### PR DESCRIPTION
This PR upgrades the Massdriver application image from version 1.0.11 to 1.0.12, updating both the Docker image tag and the Helm chart metadata to reflect the new version.