### PR TITLE
Observability (OTEL) and fixes for GKE default ingress

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.14
-appVersion: 1.1.0
+version: 0.0.15
+appVersion: 1.1.1
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -3,7 +3,7 @@ name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
 version: 0.0.15
-appVersion: 1.1.1
+appVersion: 1.2.0
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/templates/launch-control/configmap-envs.yaml
+++ b/charts/massdriver/templates/launch-control/configmap-envs.yaml
@@ -10,3 +10,14 @@ data:
   LC_PORT: "{{ .Values.launchControl.port }}"
   LC_WORKFLOW_SERVICE_ACCOUNT_NAME: {{ include "massdriver.fullname" . }}-provisioner
   MASSDRIVER_URL: "http://{{ include "massdriver.fullname" . }}-massdriver.{{ .Release.Namespace }}.svc:{{ toString .Values.massdriver.service.port }}"
+  {{- if .Values.otel.enabled }}
+  LC_PROVISIONER_OTEL_ENABLED: "{{ .Values.launchControl.provisionerOtelEnabled }}"
+  OTEL_RESOURCE_ATTRIBUTES: {{ .Values.otel.resourceAttributes | quote }}
+  OTEL_SERVICE_NAME: {{ .Values.otel.serviceName | quote }}
+  {{- if eq .Values.otel.exporter "otlp" }}
+  OTEL_TRACES_EXPORTER: otlp
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.otel.otlp.endpoint | quote }}
+  OTEL_EXPORTER_OTLP_HEADERS: {{ .Values.otel.otlp.headers | quote }}
+  OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.otel.otlp.protocol | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/massdriver/templates/massdriver/configmap-envs.yaml
+++ b/charts/massdriver/templates/massdriver/configmap-envs.yaml
@@ -28,7 +28,16 @@ data:
   MD_METRICS_SERVER_PORT: {{ .Values.massdriver.metrics.port | toString | quote }}
   MD_REPOSITORY_BUCKET: {{ .Values.massdriver.blobStorage.massdriverBucket }}
   MIX_ENV: prod
-  OTEL_RESOURCE_ATTRIBUTES: service.name=massdriver
+  {{- if .Values.otel.enabled }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ .Values.otel.resourceAttributes | quote }}
+  OTEL_SERVICE_NAME: {{ .Values.otel.serviceName | quote }}
+  {{- if eq .Values.otel.exporter "otlp" }}
+  OTEL_TRACES_EXPORTER: otlp
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.otel.otlp.endpoint | quote }}
+  OTEL_EXPORTER_OTLP_HEADERS: {{ .Values.otel.otlp.headers | quote }}
+  OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.otel.otlp.protocol | quote }}
+  {{- end }}
+  {{- end }}
   PHX_CHECK_ORIGIN: //{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},//{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
   PHX_CORS_ORIGINS: {{ include "massdriver.protocol" . }}://www.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }}
   PHX_HTTP_PORT: {{ .Values.massdriver.port | toString | quote }}

--- a/charts/massdriver/templates/massdriver/ingress.yaml
+++ b/charts/massdriver/templates/massdriver/ingress.yaml
@@ -26,7 +26,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "massdriver.fullname" . }}-massdriver
@@ -36,7 +36,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "massdriver.fullname" . }}-massdriver

--- a/charts/massdriver/templates/massdriver/job-db-migration.yaml
+++ b/charts/massdriver/templates/massdriver/job-db-migration.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "massdriver.fullname" . }}-massdriver-migration-{{ .Release.Revision }}
   labels:
     {{- include "massdriver.labels" . | nindent 4 }}
-    app.kubernetes.io/component: massdriver
+    app.kubernetes.io/component: migration
 spec:
   template:
     metadata:
@@ -18,7 +18,7 @@ spec:
         {{- with .Values.massdriver.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        app.kubernetes.io/component: massdriver
+        app.kubernetes.io/component: migration
     spec:
       restartPolicy: Never
       imagePullSecrets:

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -15,13 +15,13 @@ data:
   MD_CLOAK_KEY: {{ include "massdriver.cloakKey" . | b64enc | quote }}
   MD_GRAPHQL_SUBSCRIPTION_SECRET_KEY: {{ include "massdriver.graphqlSubscriptionSecretKey" . | b64enc | quote }}
   {{- range .Values.oidc }}
-  {{- $name := .name | upper }}
-  MD_OIDC__{{ $name }}__AUTHORIZE_URL: {{ .authorizeUrl | b64enc | quote }}
-  MD_OIDC__{{ $name }}__CLIENT_ID: {{ .clientId | b64enc | quote }}
-  MD_OIDC__{{ $name }}__CLIENT_SECRET: {{ .clientSecret | b64enc | quote }}
-  MD_OIDC__{{ $name }}__TOKEN_URL: {{ .tokenUrl | b64enc | quote }}
+  {{- $provider := .provider | upper }}
+  MD_OIDC__{{ $provider }}__AUTHORIZE_URL: {{ .authorizeUrl | b64enc | quote }}
+  MD_OIDC__{{ $provider }}__CLIENT_ID: {{ .clientId | b64enc | quote }}
+  MD_OIDC__{{ $provider }}__CLIENT_SECRET: {{ .clientSecret | b64enc | quote }}
+  MD_OIDC__{{ $provider }}__TOKEN_URL: {{ .tokenUrl | b64enc | quote }}
   {{- if not (empty .autojoinOrganization) }}
-  MD_OIDC__{{ $name }}__AUTOJOIN_ORGANIZATION: {{ .autojoinOrganization | b64enc | quote }}
+  MD_OIDC__{{ $provider }}__AUTOJOIN_ORGANIZATION: {{ .autojoinOrganization | b64enc | quote }}
   {{- end }}
   {{- end }}
   PHX_SECRET_KEY_BASE: {{ include "massdriver.phxSecretKeyBase" . | b64enc | quote }}

--- a/charts/massdriver/values-example.yaml
+++ b/charts/massdriver/values-example.yaml
@@ -34,8 +34,8 @@ quickstart:
 # OIDC configuration
 oidc: []
   # This is the OIDC configuration for Massdriver. Uncomment and fill in the values below to enable OIDC
-  # "name" must consist of alphanumeric characters only (uppercase and lowercase letters, and numbers). No spaces, dashes, or underscores are allowed.
-  # - name: 
+  # Valid providers are "google", "github" and "microsoft"
+  # - provider: 
   #   authorizeUrl:
   #   tokenUrl:
   #   clientId: 

--- a/charts/massdriver/values.schema.json
+++ b/charts/massdriver/values.schema.json
@@ -32,13 +32,12 @@
       "description": "OpenID Connect configurations for authentication",
       "items": {
         "type": "object",
-        "required": ["name", "authorizeUrl", "tokenUrl", "clientId", "clientSecret"],
+        "required": ["provider", "authorizeUrl", "tokenUrl", "clientId", "clientSecret"],
         "properties": {
-          "name": {
+          "provider": {
             "type": "string",
-            "minLength": 1,
             "description": "The name of the OIDC provider",
-            "pattern": "^[a-zA-Z0-9]+$"
+            "enum": ["github", "google", "microsoft"]
           },
           "authorizeUrl": {
             "type": "string",

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -31,11 +31,17 @@ quickstart:
 nameOverride: ""
 fullnameOverride: ""
 
+# OpenTelemetry configuration for observability and tracing
 otel:
+  # Enable OpenTelemetry export
   enabled: false
+  # Service name for trace identification
   serviceName: massdriver
+  # Exporter type (otlp, jaeger, zipkin, etc.)
   exporter: otlp
+  # Resource attributes for trace metadata
   resourceAttributes: "service.name=massdriver"
+  # OTLP exporter configuration - these fields become environment variables
   # otlp:
   #   endpoint: 
   #   headers:
@@ -74,7 +80,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.1.1"
+    tag: "1.2.0"
 
   port: 4000
 
@@ -287,8 +293,8 @@ ui:
 # OIDC configuration
 oidc: []
   # This is the OIDC configuration for Massdriver. Uncomment and fill in the values below to enable OIDC
-  # "name" must consist of alphanumeric characters only (uppercase and lowercase letters, and numbers). No spaces, dashes, or underscores are allowed.
-  # - name: 
+  # Valid providers are "google", "github" and "microsoft"
+  # - provider: 
   #   authorizeUrl:
   #   tokenUrl:
   #   clientId: 

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -31,6 +31,16 @@ quickstart:
 nameOverride: ""
 fullnameOverride: ""
 
+otel:
+  enabled: false
+  serviceName: massdriver
+  exporter: otlp
+  resourceAttributes: "service.name=massdriver"
+  # otlp:
+  #   endpoint: 
+  #   headers:
+  #   protocol: grpc
+
 # Massdriver Variables
 massdriver:
   logLevel: info
@@ -64,7 +74,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.1.0"
+    tag: "1.1.1"
 
   port: 4000
 
@@ -78,7 +88,7 @@ massdriver:
   
   livenessProbe: {}
     # httpGet:
-    #   path: /
+    #   path: /_health
     #   port: http
   readinessProbe: 
     failureThreshold: 3
@@ -162,13 +172,14 @@ massdriver:
 
 # Launch Control Variables
 launchControl:
+  provisionerOtelEnabled: true
 
   replicaCount: 2
 
   image:
     repository: massdrivercloud/launch-control
     pullPolicy: IfNotPresent
-    tag: "1.0.2"
+    tag: "1.0.3"
 
   port: 8080
 
@@ -182,7 +193,7 @@ launchControl:
   
   livenessProbe: {}
     # httpGet:
-    #   path: /
+    #   path: /healthz
     #   port: http
   readinessProbe: 
     failureThreshold: 3
@@ -235,7 +246,7 @@ ui:
   image:
     repository: massdrivercloud/massdriver-ui
     pullPolicy: IfNotPresent
-    tag: "1.0.9"
+    tag: "1.0.10"
 
   port: 3000
 
@@ -249,9 +260,17 @@ ui:
   
   livenessProbe: {}
     # httpGet:
-    #   path: /
-    #   port: http
-  readinessProbe: {}
+    #   path: /health
+    #   port: ui
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /health
+      port: ui
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 2
+    timeoutSeconds: 1
 
   securityContext: {}
     # capabilities:


### PR DESCRIPTION
This PR adds OpenTelemetry (OTEL) observability support and fixes GKE default ingress compatibility issues. The changes enable distributed tracing across the Massdriver platform components while addressing path matching issues with Google Kubernetes Engine's default ingress controller.

* Adds configurable OTEL support with OTLP exporter for massdriver and launch-control services
* Updates image tags for massdriver (1.1.1), launch-control (1.0.3), and UI (1.0.10) components
* Changes ingress pathType from ImplementationSpecific to Prefix for GKE compatibility
* Updates health check endpoint paths and adds readiness probe configuration for UI component