### PR TITLE
Use S3Proxy to access object storage so we can swap out cloud storage engines

### DIFF
--- a/charts/massdriver/templates/_helpers.tpl
+++ b/charts/massdriver/templates/_helpers.tpl
@@ -127,11 +127,3 @@ so we have to handle the "double" base64 encoding gracefully
 {{- define "massdriver.phxSigningSalt" -}}
   {{- include "massdriver.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (printf "%s-massdriver-envs" (include "massdriver.fullname" .)) "Length" 20 "Key" "PHX_SIGNING_SALT") }}
 {{- end -}}
-
-{{- define "massdriver.minio.password" -}}
-  {{ include "massdriver.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (printf "%s-minio" (include "massdriver.fullname" .)) "Length" 40 "Key" "rootPassword") }}
-{{- end }}
-
-{{- define "massdriver.minio.username" -}}
-  {{ include "massdriver.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (printf "%s-minio" (include "massdriver.fullname" .)) "Length" 20 "Key" "rootUser") }}
-{{- end }}

--- a/charts/massdriver/templates/massdriver/configmap-envs.yaml
+++ b/charts/massdriver/templates/massdriver/configmap-envs.yaml
@@ -6,16 +6,9 @@ metadata:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: massdriver
 data:
-  {{- if eq .Values.massdriver.blobStorage.type "minio" }}
-  BLOB_STORAGE_HOST: "{{ include "massdriver.fullname" . }}-minio.{{ .Release.Namespace }}.svc"
-  BLOB_STORAGE_PORT: "{{ toString .Values.minio.service.port }}"
+  BLOB_STORAGE_HOST: "{{ include "massdriver.fullname" . }}-s3proxy.{{ .Release.Namespace }}.svc"
+  BLOB_STORAGE_PORT: "80"
   BLOB_STORAGE_SCHEME: http
-  {{- else if eq .Values.massdriver.blobStorage.type "s3" }}
-  AWS_REGION: {{ .Values.massdriver.blobStorage.s3.region }}
-  BLOB_STORAGE_HOST: "{{ printf "s3.%s.amazonaws.com" .Values.massdriver.blobStorage.s3.region }}"
-  BLOB_STORAGE_PORT: "443"
-  BLOB_STORAGE_SCHEME: "https"
-  {{- end }}
   DATABASE_SSL: "true"
   FORCE_V2_LOGGING: "true"
   LOG_LEVEL: {{ .Values.massdriver.logLevel | quote }}

--- a/charts/massdriver/templates/massdriver/deployment.yaml
+++ b/charts/massdriver/templates/massdriver/deployment.yaml
@@ -20,7 +20,6 @@ spec:
         configmap.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-envs.yaml") . | sha256sum }}
         configmap.ui-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/configmap-ui.yaml") . | sha256sum }}
         secret.massdriver-envs/checksum: {{ include (print $.Template.BasePath "/massdriver/secret-envs.yaml") . | sha256sum }}
-        secret.minio/checksum: {{ include (print $.Template.BasePath "/massdriver/secret-minio.yaml") . | sha256sum }}
       labels:
         {{- include "massdriver.labels" . | nindent 8 }}
         {{- with .Values.massdriver.podLabels }}
@@ -49,10 +48,6 @@ spec:
                 name: {{ include "massdriver.fullname" . }}-massdriver-envs
             - secretRef:
                 name: {{ include "massdriver.fullname" . }}-massdriver-envs
-            {{- if and .Values.minio.enabled (eq .Values.massdriver.blobStorage.type "minio") }}
-            - secretRef:
-                name: {{ include "massdriver.fullname" . }}-massdriver-minio-auth
-            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.massdriver.port }}

--- a/charts/massdriver/templates/massdriver/job-db-migration.yaml
+++ b/charts/massdriver/templates/massdriver/job-db-migration.yaml
@@ -37,10 +37,6 @@ spec:
                 name: {{ include "massdriver.fullname" . }}-massdriver-envs
             - secretRef:
                 name: {{ include "massdriver.fullname" . }}-massdriver-envs
-            {{- if and .Values.minio.enabled (eq .Values.massdriver.blobStorage.type "minio") }}
-            - secretRef:
-                name: {{ include "massdriver.fullname" . }}-massdriver-minio-auth
-            {{- end }}
           args: 
             - eval
             - Massdriver.Release.migrate

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -6,10 +6,8 @@ metadata:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: massdriver
 data:
-  {{- if and (eq .Values.massdriver.blobStorage.type "s3") (not (empty .Values.massdriver.blobStorage.s3.accessKeyId)) (not (empty .Values.massdriver.blobStorage.s3.secretAccessKey)) }}
-  AWS_ACCESS_KEY_ID: {{ .Values.massdriver.blobStorage.s3.accessKeyId | b64enc | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.massdriver.blobStorage.s3.secretAccessKey | b64enc | quote }}
-  {{- end }}
+  AWS_ACCESS_KEY_ID: {{ .Values.massdriver.blobStorage.username | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.massdriver.blobStorage.password | b64enc | quote }}
   JWT_SECRET: {{ include "massdriver.jwtSecret" . | b64enc | quote }}
   LICENSE_KEY: {{ .Values.licenseKey | b64enc | quote }}
   MD_CLOAK_KEY: {{ include "massdriver.cloakKey" . | b64enc | quote }}

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: {{ .Values.massdriver.blobStorage.username | b64enc | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.massdriver.blobStorage.password | b64enc | quote }}
+  AWS_REGION: {{ "us-east-1" | b64enc | quote }}
   JWT_SECRET: {{ include "massdriver.jwtSecret" . | b64enc | quote }}
   LICENSE_KEY: {{ .Values.licenseKey | b64enc | quote }}
   MD_CLOAK_KEY: {{ include "massdriver.cloakKey" . | b64enc | quote }}

--- a/charts/massdriver/templates/massdriver/secret-minio.yaml
+++ b/charts/massdriver/templates/massdriver/secret-minio.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.minio.enabled -}}
-{{- $minioUser := include "massdriver.minio.username" . }}
-{{- $minioPassword := include "massdriver.minio.password" . }}
 apiVersion: v1
 kind: Secret
 metadata: 
@@ -9,20 +7,6 @@ metadata:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio
 data:
-  rootUser: {{ $minioUser | b64enc | quote }}
-  rootPassword: {{ $minioPassword | b64enc | quote }}
----
-# this secret is used by massdriver to authenticate with minio - it is here so that the secret generator will be consistent on install
-{{- if eq .Values.massdriver.blobStorage.type "minio" }}
-apiVersion: v1
-kind: Secret
-metadata: 
-  name: {{ include "massdriver.fullname" . }}-massdriver-minio-auth
-  labels:
-    {{- include "massdriver.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio
-data:
-  AWS_ACCESS_KEY_ID: {{ $minioUser | b64enc | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ $minioPassword | b64enc | quote }}
-{{- end }}
-{{- end }}
+  rootUser: {{ .Values.massdriver.blobStorage.minio.username | b64enc | quote }}
+  rootPassword: {{ .Values.massdriver.blobStorage.minio.password | b64enc | quote }}
+{{- end -}}

--- a/charts/massdriver/templates/s3proxy/configmap.yaml
+++ b/charts/massdriver/templates/s3proxy/configmap.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "massdriver.fullname" . }}-s3proxy-envs
+  labels:
+    {{- include "massdriver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3proxy
+data:
+  # S3Proxy configuration
+  S3PROXY_ENDPOINT: "http://0.0.0.0:8080"
+  S3PROXY_AUTHORIZATION: "aws-v2-or-v4"
+  S3PROXY_IDENTITY: {{ .Values.massdriver.blobStorage.username | quote }}
+  S3PROXY_CREDENTIAL: {{ .Values.massdriver.blobStorage.password | quote }}
+  S3PROXY_VIRTUALHOST: ""
+  S3PROXY_IGNORE_UNKNOWN_HEADERS: "true"
+  S3PROXY_CORS_ALLOW_ALL: "false"
+  
+  {{- if eq .Values.massdriver.blobStorage.type "minio" }}
+  # MinIO backend configuration (using S3 provider)
+  JCLOUDS_PROVIDER: "aws-s3"
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.minio.username | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.minio.password | quote }}
+  JCLOUDS_ENDPOINT: "http://{{ include "massdriver.fullname" . }}-minio.{{ .Release.Namespace }}.svc:{{ toString .Values.minio.service.port }}"
+  {{- else if eq .Values.massdriver.blobStorage.type "s3" }}
+  # AWS S3 Configuration
+  JCLOUDS_PROVIDER: "aws-s3"
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.s3.accessKeyId | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.s3.secretAccessKey | quote }}
+  JCLOUDS_ENDPOINT: "{{ printf "https://s3.%s.amazonaws.com" .Values.massdriver.blobStorage.s3.region }}"
+  JCLOUDS_REGION: {{ .Values.massdriver.blobStorage.s3.region | quote }}
+  {{- else if eq .Values.massdriver.blobStorage.type "gcs" }}
+  # Google Cloud Storage Configuration
+  JCLOUDS_PROVIDER: "google-cloud-storage"
+  # JCLOUDS_IDENTITY: "<SERVICE_ACCOUNT_EMAIL>"
+  # JCLOUDS_CREDENTIAL: "<PRIVATE_KEY>"
+  {{- else if eq .Values.massdriver.blobStorage.type "azureblob" }}
+  # Azure Blob Storage Configuration
+  JCLOUDS_PROVIDER: "azureblob-sdk"
+  JCLOUDS_ENDPOINT: "https://{{ .Values.massdriver.blobStorage.azureblob.storageAccountName }}.blob.core.windows.net"
+  {{- if not (empty .Values.massdriver.blobStorage.azureblob.storageAccountKey) }}
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.azureblob.storageAccountName | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.azureblob.storageAccountKey | quote }}
+  {{- else }}
+  JCLOUDS_IDENTITY: ""
+  JCLOUDS_CREDENTIAL: ""
+  AZURE_TENANT_ID: {{ .Values.massdriver.blobStorage.azureblob.tenantId | quote }}
+  AZURE_CLIENT_ID: {{ .Values.massdriver.blobStorage.azureblob.clientId | quote }}
+  AZURE_CLIENT_SECRET: {{ .Values.massdriver.blobStorage.azureblob.clientSecret | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/massdriver/templates/s3proxy/configmap.yaml
+++ b/charts/massdriver/templates/s3proxy/configmap.yaml
@@ -14,7 +14,13 @@ data:
   S3PROXY_VIRTUALHOST: ""
   S3PROXY_IGNORE_UNKNOWN_HEADERS: "true"
   S3PROXY_CORS_ALLOW_ALL: "false"
-  
+
+  # JClouds HTTP client performance optimizations (applies to all providers)
+  JCLOUDS_CONNECTION_TIMEOUT: "5000"
+  JCLOUDS_SO_TIMEOUT: "10000"
+  JCLOUDS_MAX_CONNECTIONS: "200"
+  JCLOUDS_MAX_CONNECTIONS_PER_ROUTE: "20"
+
   {{- if eq .Values.massdriver.blobStorage.type "minio" }}
   # MinIO backend configuration (using S3 provider)
   JCLOUDS_PROVIDER: "aws-s3"
@@ -31,8 +37,9 @@ data:
   {{- else if eq .Values.massdriver.blobStorage.type "gcs" }}
   # Google Cloud Storage Configuration
   JCLOUDS_PROVIDER: "google-cloud-storage"
-  # JCLOUDS_IDENTITY: "<SERVICE_ACCOUNT_EMAIL>"
-  # JCLOUDS_CREDENTIAL: "<PRIVATE_KEY>"
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.gcs.serviceAccountEmail | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.gcs.privateKey | quote }}
+  JCLOUDS_ENDPOINT: "https://storage.googleapis.com"
   {{- else if eq .Values.massdriver.blobStorage.type "azureblob" }}
   # Azure Blob Storage Configuration
   JCLOUDS_PROVIDER: "azureblob-sdk"

--- a/charts/massdriver/templates/s3proxy/deployment.yaml
+++ b/charts/massdriver/templates/s3proxy/deployment.yaml
@@ -52,6 +52,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "massdriver.fullname" . }}-s3proxy-envs
+          # {{- if eq .Values.massdriver.blobStorage.type "gcs" }}
+          # volumeMounts:
+          #   - name: gcs-credentials
+          #     mountPath: /etc/s3proxy/gcs-credentials
+          #     readOnly: true
+          # {{- end }}
           securityContext:
             capabilities:
               drop:
@@ -59,5 +65,12 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
             runAsUser: 65534
+      # {{- if eq .Values.massdriver.blobStorage.type "gcs" }}
+      # volumes:
+      #   - name: gcs-credentials
+      #     secret:
+      #       secretName: {{ include "massdriver.fullname" . }}-s3proxy-gcs-key
+      #       defaultMode: 0400
+      # {{- end }}
       securityContext:
         fsGroup: 65534

--- a/charts/massdriver/templates/s3proxy/deployment.yaml
+++ b/charts/massdriver/templates/s3proxy/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "massdriver.fullname" . }}-s3proxy
+  labels:
+    {{- include "massdriver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3proxy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      {{- include "massdriver.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: s3proxy
+  template:
+    metadata:
+      annotations:
+        configmap.s3proxy-config/checksum: {{ include (print $.Template.BasePath "/s3proxy/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "massdriver.labels" . | nindent 8 }}
+        app.kubernetes.io/component: s3proxy
+    spec:
+      serviceAccountName: {{ include "massdriver.fullname" . }}-s3proxy
+      containers:
+        - name: s3proxy
+          image: "andrewgaul/s3proxy:3.0.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          envFrom:
+            - configMapRef:
+                name: {{ include "massdriver.fullname" . }}-s3proxy-envs
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65534
+      securityContext:
+        fsGroup: 65534

--- a/charts/massdriver/templates/s3proxy/deployment.yaml
+++ b/charts/massdriver/templates/s3proxy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        configmap.s3proxy-config/checksum: {{ include (print $.Template.BasePath "/s3proxy/configmap.yaml") . | sha256sum }}
+        secret.s3proxy-config/checksum: {{ include (print $.Template.BasePath "/s3proxy/secret-envs.yaml") . | sha256sum }}
       labels:
         {{- include "massdriver.labels" . | nindent 8 }}
         app.kubernetes.io/component: s3proxy
@@ -50,14 +50,8 @@ spec:
               cpu: 100m
               memory: 128Mi
           envFrom:
-            - configMapRef:
+            - secretRef:
                 name: {{ include "massdriver.fullname" . }}-s3proxy-envs
-          # {{- if eq .Values.massdriver.blobStorage.type "gcs" }}
-          # volumeMounts:
-          #   - name: gcs-credentials
-          #     mountPath: /etc/s3proxy/gcs-credentials
-          #     readOnly: true
-          # {{- end }}
           securityContext:
             capabilities:
               drop:
@@ -65,12 +59,5 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
             runAsUser: 65534
-      # {{- if eq .Values.massdriver.blobStorage.type "gcs" }}
-      # volumes:
-      #   - name: gcs-credentials
-      #     secret:
-      #       secretName: {{ include "massdriver.fullname" . }}-s3proxy-gcs-key
-      #       defaultMode: 0400
-      # {{- end }}
       securityContext:
         fsGroup: 65534

--- a/charts/massdriver/templates/s3proxy/secret-envs.yaml
+++ b/charts/massdriver/templates/s3proxy/secret-envs.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "massdriver.fullname" . }}-s3proxy-envs
   labels:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3proxy
-data:
+type: Opaque
+stringData:
   # S3Proxy configuration
   S3PROXY_ENDPOINT: "http://0.0.0.0:8080"
   S3PROXY_AUTHORIZATION: "aws-v2-or-v4"

--- a/charts/massdriver/templates/s3proxy/secret-envs.yaml
+++ b/charts/massdriver/templates/s3proxy/secret-envs.yaml
@@ -6,57 +6,51 @@ metadata:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3proxy
 type: Opaque
-stringData:
+data:
   # S3Proxy configuration
-  S3PROXY_ENDPOINT: "http://0.0.0.0:8080"
-  S3PROXY_AUTHORIZATION: "aws-v2-or-v4"
-  S3PROXY_IDENTITY: {{ .Values.massdriver.blobStorage.username | quote }}
-  S3PROXY_CREDENTIAL: {{ .Values.massdriver.blobStorage.password | quote }}
-  S3PROXY_VIRTUALHOST: ""
-  S3PROXY_IGNORE_UNKNOWN_HEADERS: "true"
-  S3PROXY_CORS_ALLOW_ALL: "false"
+  S3PROXY_ENDPOINT: {{ "http://0.0.0.0:8080" | b64enc | quote }}
+  S3PROXY_AUTHORIZATION: {{ "aws-v4" | b64enc | quote }}
+  S3PROXY_IDENTITY: {{ .Values.massdriver.blobStorage.username | b64enc | quote }}
+  S3PROXY_CREDENTIAL: {{ .Values.massdriver.blobStorage.password | b64enc | quote }}
+  S3PROXY_VIRTUALHOST: {{ "" | b64enc | quote }}
+  S3PROXY_IGNORE_UNKNOWN_HEADERS: {{ "true" | b64enc | quote }}
+  S3PROXY_CORS_ALLOW_ALL: {{ "false" | b64enc | quote }}
 
   # Logging configuration for debugging
-  LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | quote }}
-  JETTY_LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | quote }}
-
-  # JClouds HTTP client performance optimizations (applies to all providers)
-  JCLOUDS_CONNECTION_TIMEOUT: "5000"
-  JCLOUDS_SO_TIMEOUT: "10000"
-  JCLOUDS_MAX_CONNECTIONS: "200"
-  JCLOUDS_MAX_CONNECTIONS_PER_ROUTE: "20"
+  LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | b64enc | quote }}
+  JETTY_LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | b64enc | quote }}
 
   {{- if eq .Values.massdriver.blobStorage.type "minio" }}
-  # MinIO backend configuration (using S3 provider)
-  JCLOUDS_PROVIDER: "aws-s3"
-  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.minio.username | quote }}
-  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.minio.password | quote }}
-  JCLOUDS_ENDPOINT: "http://{{ include "massdriver.fullname" . }}-minio.{{ .Release.Namespace }}.svc:{{ toString .Values.minio.service.port }}"
+  # MinIO backend configuration (using S3 SDK provider for path-style bucket addressing)
+  JCLOUDS_PROVIDER: {{ "aws-s3-sdk" | b64enc | quote }}
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.minio.username | b64enc | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.minio.password | b64enc | quote }}
+  JCLOUDS_ENDPOINT: {{ printf "http://%s-minio.%s.svc:%s" (include "massdriver.fullname" .) .Release.Namespace (toString .Values.minio.service.port) | b64enc | quote }}
   {{- else if eq .Values.massdriver.blobStorage.type "s3" }}
   # AWS S3 Configuration
-  JCLOUDS_PROVIDER: "aws-s3"
-  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.s3.accessKeyId | quote }}
-  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.s3.secretAccessKey | quote }}
-  JCLOUDS_ENDPOINT: "{{ printf "https://s3.%s.amazonaws.com" .Values.massdriver.blobStorage.s3.region }}"
-  JCLOUDS_REGION: {{ .Values.massdriver.blobStorage.s3.region | quote }}
+  JCLOUDS_PROVIDER: {{ "aws-s3" | b64enc | quote }}
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.s3.accessKeyId | b64enc | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.s3.secretAccessKey | b64enc | quote }}
+  JCLOUDS_ENDPOINT: {{ printf "https://s3.%s.amazonaws.com" .Values.massdriver.blobStorage.s3.region | b64enc | quote }}
+  JCLOUDS_REGION: {{ .Values.massdriver.blobStorage.s3.region | b64enc | quote }}
   {{- else if eq .Values.massdriver.blobStorage.type "gcs" }}
   # Google Cloud Storage Configuration
-  JCLOUDS_PROVIDER: "google-cloud-storage"
-  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.gcs.serviceAccountEmail | quote }}
-  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.gcs.privateKey | quote }}
-  JCLOUDS_ENDPOINT: "https://storage.googleapis.com"
+  JCLOUDS_PROVIDER: {{ "google-cloud-storage" | b64enc | quote }}
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.gcs.serviceAccountEmail | b64enc | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.gcs.privateKey | b64enc | quote }}
+  JCLOUDS_ENDPOINT: {{ "https://storage.googleapis.com" | b64enc | quote }}
   {{- else if eq .Values.massdriver.blobStorage.type "azureblob" }}
   # Azure Blob Storage Configuration
-  JCLOUDS_PROVIDER: "azureblob-sdk"
-  JCLOUDS_ENDPOINT: "https://{{ .Values.massdriver.blobStorage.azureblob.storageAccountName }}.blob.core.windows.net"
+  JCLOUDS_PROVIDER: {{ "azureblob-sdk" | b64enc | quote }}
+  JCLOUDS_ENDPOINT: {{ printf "https://%s.blob.core.windows.net" .Values.massdriver.blobStorage.azureblob.storageAccountName | b64enc | quote }}
   {{- if not (empty .Values.massdriver.blobStorage.azureblob.storageAccountKey) }}
-  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.azureblob.storageAccountName | quote }}
-  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.azureblob.storageAccountKey | quote }}
+  JCLOUDS_IDENTITY: {{ .Values.massdriver.blobStorage.azureblob.storageAccountName | b64enc | quote }}
+  JCLOUDS_CREDENTIAL: {{ .Values.massdriver.blobStorage.azureblob.storageAccountKey | b64enc | quote }}
   {{- else }}
-  JCLOUDS_IDENTITY: ""
-  JCLOUDS_CREDENTIAL: ""
-  AZURE_TENANT_ID: {{ .Values.massdriver.blobStorage.azureblob.tenantId | quote }}
-  AZURE_CLIENT_ID: {{ .Values.massdriver.blobStorage.azureblob.clientId | quote }}
-  AZURE_CLIENT_SECRET: {{ .Values.massdriver.blobStorage.azureblob.clientSecret | quote }}
+  JCLOUDS_IDENTITY: {{ "" | b64enc | quote }}
+  JCLOUDS_CREDENTIAL: {{ "" | b64enc | quote }}
+  AZURE_TENANT_ID: {{ .Values.massdriver.blobStorage.azureblob.tenantId | b64enc | quote }}
+  AZURE_CLIENT_ID: {{ .Values.massdriver.blobStorage.azureblob.clientId | b64enc | quote }}
+  AZURE_CLIENT_SECRET: {{ .Values.massdriver.blobStorage.azureblob.clientSecret | b64enc | quote }}
   {{- end }}
   {{- end }}

--- a/charts/massdriver/templates/s3proxy/secret-envs.yaml
+++ b/charts/massdriver/templates/s3proxy/secret-envs.yaml
@@ -16,6 +16,10 @@ stringData:
   S3PROXY_IGNORE_UNKNOWN_HEADERS: "true"
   S3PROXY_CORS_ALLOW_ALL: "false"
 
+  # Logging configuration for debugging
+  LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | quote }}
+  JETTY_LOG_LEVEL: {{ .Values.massdriver.blobStorage.logLevel | quote }}
+
   # JClouds HTTP client performance optimizations (applies to all providers)
   JCLOUDS_CONNECTION_TIMEOUT: "5000"
   JCLOUDS_SO_TIMEOUT: "10000"

--- a/charts/massdriver/templates/s3proxy/service.yaml
+++ b/charts/massdriver/templates/s3proxy/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "massdriver.fullname" . }}-s3proxy
+  labels:
+    {{- include "massdriver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "massdriver.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: s3proxy

--- a/charts/massdriver/templates/s3proxy/serviceaccount.yaml
+++ b/charts/massdriver/templates/s3proxy/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "massdriver.fullname" . }}-s3proxy
+  labels:
+    {{- include "massdriver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3proxy
+  {{- with .Values.massdriver.blobStorage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true

--- a/charts/massdriver/templates/s3proxy/serviceaccount.yaml
+++ b/charts/massdriver/templates/s3proxy/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "massdriver.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3proxy
-  {{- with .Values.massdriver.blobStorage.annotations }}
+  {{- with .Values.massdriver.blobStorage.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -47,6 +47,18 @@ otel:
   #   headers:
   #   protocol: grpc
 
+# storage:
+#   # S3Proxy credentials for authenticated access
+#   username: massdriver
+#   password: s3proxypassword
+#   # Choose the backend for persistent storage: "minio", "s3", "gcs", or "azureblob"
+#   backend: minio
+
+#   minio:
+#     # If using MinIO as the storage backend, specify the access credentials
+#     username: minioaccesskey
+#     password: miniosecretkey
+
 # Massdriver Variables
 massdriver:
   logLevel: info
@@ -57,7 +69,11 @@ massdriver:
 
   # Configuration for blob storage
   blobStorage:
-    # options are "minio" or "s3". If using "s3", make sure you set the correct bucket names and s3 values below
+    # S3Proxy credentials for authenticated access
+    username: massdriver
+    password: s3proxypassword
+
+    # options are "minio", "s3", "gcs", or "azureblob". For whichever type you
     type: minio
 
     # Bucket names for Massdriver to use. The default values will work with the included MinIO deployment.
@@ -67,6 +83,11 @@ massdriver:
     # The state bucket is used for OpenTofu/Terraform remote state storage
     stateBucket: state
 
+    # Required if using "minio" for blobStorage.type
+    minio:
+      username: minioaccesskey
+      password: miniosecretkey
+
     # Required if using "s3" for blobStorage.type
     # NOTE: Be sure to update Argo Workflows artifact repository if you wish to S3 for Argo artifacts as well
     s3:
@@ -75,6 +96,23 @@ massdriver:
       # If you aren't running in EKS or prefer to use access keys, you can set them here
       accessKeyId: ""
       secretAccessKey: ""
+
+    # Required if using "s3" for blobStorage.type
+    # NOTE: Be sure to update Argo Workflows artifact repository if you wish to S3 for Argo artifacts as well
+    azureblob:
+      region: eastus
+      # S3 access is better granted via IAM roles (IRSA for EKS) by setting the proper annotations on the service account
+      # If you aren't running in EKS or prefer to use access keys, you can set them here
+      storageAccountName: ""
+
+      # You can authenticate with either storage account key or via service principal.
+      # If using storage account key, set that value and leave the service principal values blank.
+      storageAccountKey: ""
+      
+      # If using service principal authentication, leave storageAccountKey blank and set the values below
+      clientId: ""
+      clientSecret: ""
+      tenantId: ""
 
   replicaCount: 2
 

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -57,7 +57,7 @@ massdriver:
 
   # Configuration for blob storage
   blobStorage:
-  
+
     # S3Proxy credentials for authenticated access
     username: massdriver
     password: s3proxypassword
@@ -65,12 +65,15 @@ massdriver:
     # Log level for S3Proxy (debug, info, warn, error)
     logLevel: info
 
-    # options are "minio", "s3", "gcs", or "azureblob". For whichever type you
+    # This is where you specify your desired object storage backend.
+    # Options are "minio", "s3", "gcs", or "azureblob". For whichever type you choose,
+    # be sure to fill out the corresponding configuration section below.
     type: minio
 
     # Bucket names for Massdriver to use. The default values will work with the included MinIO deployment.
-    # If you are using your own S3 buckets you will need to update the values.
-    # If you are using Azure Blob Storage, the bucket names correspond to container names.
+    # If you are using your own S3 buckets you will need to update the values to be the actual s3 bucket names (make sure they exist).
+    # If you are using Azure Blob Storage, the bucket names correspond to container names in the storage account (make sure they exist).
+    # If you are using GCS, the bucket names correspond to GCS bucket names (make sure they exist).
     # The massdriver bucket is used for bundle/OCI storage and deployment logs
     massdriverBucket: massdriver
     # The state bucket is used for OpenTofu/Terraform remote state storage
@@ -86,14 +89,14 @@ massdriver:
       password: miniosecretkey
 
     # Required if using "s3" for blobStorage.type
-    # NOTE: Be sure to update Argo Workflows artifact repository if you wish to S3 for Argo artifacts as well
     s3:
       region: us-east-1
-      # S3 access is better granted via IAM roles (IRSA for EKS) by setting the proper annotations on the service account
-      # If you aren't running in EKS or prefer to use access keys, you can set them here
+      # S3 access can be granted via access keys or IAM roles (IRSA for EKS) by setting the proper annotations on the service account
+      # If you are using access keys, set them here. If not, leave them blank and ensure the service account has the proper annotations for role binding.
       accessKeyId: ""
       secretAccessKey: ""
 
+    # Required if using "gcs" for blobStorage.type
     gcs:
       serviceAccountEmail: ""
       privateKey: |-
@@ -101,16 +104,13 @@ massdriver:
         ...
         -----END PRIVATE KEY-----
 
-    # Required if using "s3" for blobStorage.type
-    # NOTE: Be sure to update Argo Workflows artifact repository if you wish to S3 for Argo artifacts as well
+    # Required if using "azureblob" for blobStorage.type
     azureblob:
       region: eastus
-      # S3 access is better granted via IAM roles (IRSA for EKS) by setting the proper annotations on the service account
-      # If you aren't running in EKS or prefer to use access keys, you can set them here
       storageAccountName: ""
 
       # You can authenticate with either storage account key or via service principal.
-      # If using storage account key, set that value and leave the service principal values blank.
+      # If using storage account key, set the value here and leave the service principal values blank.
       storageAccountKey: ""
 
       # If using service principal authentication, leave storageAccountKey blank and set the values below

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -57,9 +57,13 @@ massdriver:
 
   # Configuration for blob storage
   blobStorage:
+  
     # S3Proxy credentials for authenticated access
     username: massdriver
     password: s3proxypassword
+
+    # Log level for S3Proxy (debug, info, warn, error)
+    logLevel: info
 
     # options are "minio", "s3", "gcs", or "azureblob". For whichever type you
     type: minio

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -55,7 +55,7 @@ massdriver:
   apiSubdomain: api
   appSubdomain: app
 
-  # Configuration for blob storage
+  # Configuration for blob storage. This includes deployment logs, bundle/OCI storage, and Terraform/OpenTofu remote state.
   blobStorage:
 
     # S3Proxy credentials for authenticated access
@@ -66,8 +66,7 @@ massdriver:
     logLevel: info
 
     # This is where you specify your desired object storage backend.
-    # Options are "minio", "s3", "gcs", or "azureblob". For whichever type you choose,
-    # be sure to fill out the corresponding configuration section below.
+    # Options are "minio", "s3", "gcs", or "azureblob". For whichever type you choose, be sure to fill out the corresponding configuration section below.
     type: minio
 
     # Bucket names for Massdriver to use. The default values will work with the included MinIO deployment.
@@ -79,9 +78,17 @@ massdriver:
     # The state bucket is used for OpenTofu/Terraform remote state storage
     stateBucket: state
 
-    # Additional annotations to add to the ServiceAccount used by S3Proxy
-    # This is useful for adding dynamic IAM role bindings
-    annotations: {}
+    serviceAccount:
+      # Annotations to add to the ServiceAccount used by S3Proxy
+      # This can be used to attach cloud IAM roles/identities to the pod via ServiceAccount annotations.
+      # Examples:
+      #   - AWS EKS (IRSA):
+      #       eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/YourS3ProxyRole
+      #   - GKE Workload Identity:
+      #       iam.gke.io/gcp-service-account: your-sa@your-gcp-project.iam.gserviceaccount.com
+      #   - Azure Workload Identity:
+      #       azure.workload.identity/client-id: "<azure-ad-app-client-id>"
+      annotations: {}
 
     # Required if using "minio" for blobStorage.type
     minio:
@@ -106,7 +113,6 @@ massdriver:
 
     # Required if using "azureblob" for blobStorage.type
     azureblob:
-      region: eastus
       storageAccountName: ""
 
       # You can authenticate with either storage account key or via service principal.

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -47,18 +47,6 @@ otel:
   #   headers:
   #   protocol: grpc
 
-# storage:
-#   # S3Proxy credentials for authenticated access
-#   username: massdriver
-#   password: s3proxypassword
-#   # Choose the backend for persistent storage: "minio", "s3", "gcs", or "azureblob"
-#   backend: minio
-
-#   minio:
-#     # If using MinIO as the storage backend, specify the access credentials
-#     username: minioaccesskey
-#     password: miniosecretkey
-
 # Massdriver Variables
 massdriver:
   logLevel: info
@@ -78,10 +66,15 @@ massdriver:
 
     # Bucket names for Massdriver to use. The default values will work with the included MinIO deployment.
     # If you are using your own S3 buckets you will need to update the values.
-    # The massdriver bucket is used for bundle and OCI storage
+    # If you are using Azure Blob Storage, the bucket names correspond to container names.
+    # The massdriver bucket is used for bundle/OCI storage and deployment logs
     massdriverBucket: massdriver
     # The state bucket is used for OpenTofu/Terraform remote state storage
     stateBucket: state
+
+    # Additional annotations to add to the ServiceAccount used by S3Proxy
+    # This is useful for adding dynamic IAM role bindings
+    annotations: {}
 
     # Required if using "minio" for blobStorage.type
     minio:
@@ -97,6 +90,13 @@ massdriver:
       accessKeyId: ""
       secretAccessKey: ""
 
+    gcs:
+      serviceAccountEmail: ""
+      privateKey: |-
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
+
     # Required if using "s3" for blobStorage.type
     # NOTE: Be sure to update Argo Workflows artifact repository if you wish to S3 for Argo artifacts as well
     azureblob:
@@ -108,7 +108,7 @@ massdriver:
       # You can authenticate with either storage account key or via service principal.
       # If using storage account key, set that value and leave the service principal values blank.
       storageAccountKey: ""
-      
+
       # If using service principal authentication, leave storageAccountKey blank and set the values below
       clientId: ""
       clientSecret: ""


### PR DESCRIPTION
This pull request introduces S3Proxy as an abstraction layer for object storage access in Massdriver, enabling support for multiple cloud storage backends (MinIO, AWS S3, Google Cloud Storage, and Azure Blob Storage) through a unified interface. The change replaces direct storage access with a proxy-based approach that simplifies multi-cloud deployments.

Changes:

* Introduced S3Proxy deployment with support for MinIO, S3, GCS, and Azure Blob Storage backends
* Refactored Massdriver application to connect to S3Proxy instead of directly to storage backends
* Consolidated storage credentials management and added configuration for multiple cloud providers