### PR TITLE
expose phoenix cors/origins, update naming

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.0.25
-appVersion: 1.3.2
+version: 0.0.26
+appVersion: 1.4.0
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/templates/_helpers.tpl
+++ b/charts/massdriver/templates/_helpers.tpl
@@ -127,3 +127,38 @@ so we have to handle the "double" base64 encoding gracefully
 {{- define "massdriver.phxSigningSalt" -}}
   {{- include "massdriver.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (printf "%s-massdriver-envs" (include "massdriver.fullname" .)) "Length" 20 "Key" "PHX_SIGNING_SALT") }}
 {{- end -}}
+
+{{/*
+PHX_CHECK_ORIGIN value — scheme-relative origins for Phoenix WebSocket/LiveView checks.
+Includes the core api/app subdomains, any additionalSubdomains (short names under the base domain),
+and any additionalOrigins (full URLs, protocol stripped).
+*/}}
+{{- define "massdriver.phxCheckOrigins" -}}
+  {{- $domain := .Values.domain -}}
+  {{- $origins := list (printf "//%s.%s" .Values.massdriver.apiSubdomain $domain) (printf "//%s.%s" .Values.massdriver.appSubdomain $domain) -}}
+  {{- range .Values.massdriver.additionalSubdomains -}}
+    {{- $origins = append $origins (printf "//%s.%s" . $domain) -}}
+  {{- end -}}
+  {{- range .Values.massdriver.additionalOrigins -}}
+    {{- $origins = append $origins (trimPrefix "https:" . | trimPrefix "http:") -}}
+  {{- end -}}
+  {{- join "," $origins -}}
+{{- end -}}
+
+{{/*
+PHX_CORS_ORIGINS value — full URLs for HTTP CORS policy.
+Includes www + core api/app subdomains, any additionalSubdomains (short names under the base domain),
+and any additionalOrigins (full URLs for external tools like Backstage or Port).
+*/}}
+{{- define "massdriver.corsOrigins" -}}
+  {{- $protocol := include "massdriver.protocol" . -}}
+  {{- $domain := .Values.domain -}}
+  {{- $origins := list (printf "%s://www.%s" $protocol $domain) (printf "%s://%s.%s" $protocol .Values.massdriver.apiSubdomain $domain) (printf "%s://%s.%s" $protocol .Values.massdriver.appSubdomain $domain) -}}
+  {{- range .Values.massdriver.additionalSubdomains -}}
+    {{- $origins = append $origins (printf "%s://%s.%s" $protocol . $domain) -}}
+  {{- end -}}
+  {{- range .Values.massdriver.additionalOrigins -}}
+    {{- $origins = append $origins . -}}
+  {{- end -}}
+  {{- join "," $origins -}}
+{{- end -}}

--- a/charts/massdriver/templates/launch-control/configmap-envs.yaml
+++ b/charts/massdriver/templates/launch-control/configmap-envs.yaml
@@ -21,3 +21,6 @@ data:
   OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.otel.otlp.protocol | quote }}
   {{- end }}
   {{- end }}
+  {{- range $key, $value := .Values.launchControl.additionalEnvs }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}

--- a/charts/massdriver/templates/massdriver/configmap-envs.yaml
+++ b/charts/massdriver/templates/massdriver/configmap-envs.yaml
@@ -31,14 +31,14 @@ data:
   OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.otel.otlp.protocol | quote }}
   {{- end }}
   {{- end }}
-  PHX_CHECK_ORIGIN: //{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},//{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }},//dev.{{ .Values.domain }}
-  PHX_CORS_ORIGINS: {{ include "massdriver.protocol" . }}://www.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://{{ .Values.massdriver.appSubdomain }}.{{ .Values.domain }},{{ include "massdriver.protocol" . }}://dev.{{ .Values.domain }}
+  PHX_CHECK_ORIGIN: {{ include "massdriver.phxCheckOrigins" . }}
+  PHX_CORS_ORIGINS: {{ include "massdriver.corsOrigins" . }}
   PHX_HTTP_PORT: {{ .Values.massdriver.port | toString | quote }}
   PHX_SERVER: "true"
   PHX_URL_HOST: {{ .Values.massdriver.apiSubdomain }}.{{ .Values.domain }}
   PHX_URL_PORT: "{{ if eq (include "massdriver.protocol" .) "https" }}443{{ else }}80{{ end }}"
   PHX_URL_SCHEME: {{ include "massdriver.protocol" . }}
   TERRAFORM_STATE_BUCKET_NAME: {{ .Values.massdriver.blobStorage.stateBucket }}
-{{- range $key, $value := .Values.massdriver.extraEnvs }}
+  {{- range $key, $value := .Values.massdriver.additionalEnvs }}
   {{ $key }}: {{ $value | toString | quote }}
-{{- end }}
+  {{- end }}

--- a/charts/massdriver/templates/massdriver/secret-envs.yaml
+++ b/charts/massdriver/templates/massdriver/secret-envs.yaml
@@ -45,6 +45,6 @@ data:
   SMTP_PORT: {{ .Values.smtp.port | toString | b64enc | quote }}
   SMTP_SERVER: {{ .Values.smtp.server | b64enc | quote }}
   SMTP_USERNAME: {{ .Values.smtp.username | b64enc | quote }}
-{{- range $key, $value := .Values.massdriver.extraSecrets }}
+  {{- range $key, $value := .Values.massdriver.additionalSecrets }}
   {{ $key }}: {{ $value | toString | b64enc | quote }}
-{{- end }}
+  {{- end }}

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -138,7 +138,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "1.3.2"
+    tag: "1.4.0"
 
   port: 4000
 

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -54,6 +54,15 @@ massdriver:
   # The subdomains to use for Massdriver. These will be used to construct URLs for the frontend and API.
   apiSubdomain: api
   appSubdomain: app
+  
+  # Additional subdomains of the base domain to allow in CORS and Phoenix origin checks. This should rarely be needed in self-hosted environments.
+  # The chart will automatically format these for both PHX_CORS_ORIGINS and PHX_CHECK_ORIGIN.
+  additionalSubdomains: []
+
+  # Fully qualified origins to allow, for external tools on different domains.
+  # Provide full HTTPS URLs — the chart will derive the host-only form for PHX_CHECK_ORIGIN automatically.
+  # Example: ["https://custom.service.internal.company.com"]
+  additionalOrigins: []
 
   # Configuration for blob storage. This includes deployment logs, bundle/OCI storage, and Terraform/OpenTofu remote state.
   blobStorage:
@@ -134,9 +143,9 @@ massdriver:
 
   # Additional environment variables to set on the Massdriver container in the Massdriver deployment
   # Format is a map of key/value pairs (not the list of name/value objects like Kubernetes uses)
-  # These will be added to the ConfigMap (extraEnvs) or Secrets (extraSecrets) and then mounted into the deployment.
-  extraEnvs: {}
-  extraSecrets: {}
+  # These will be added to the ConfigMap (additionalEnvs) or Secrets (extraSecrets) and then mounted into the deployment.
+  additionalEnvs: {}
+  additionalSecrets: {}
 
   resources:
     limits:
@@ -265,6 +274,11 @@ launchControl:
     tag: "1.0.4"
 
   port: 8080
+
+  # Additional environment variables to set on the Launch Control container in the Massdriver deployment
+  # Format is a map of key/value pairs (not the list of name/value objects like Kubernetes uses)
+  # These will be added to the ConfigMap and then mounted into the deployment.
+  additionalEnvs: {}
 
   resources:
     limits:

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -60,7 +60,8 @@ massdriver:
   additionalSubdomains: []
 
   # Fully qualified origins to allow, for external tools on different domains.
-  # Provide full HTTPS URLs — the chart will derive the host-only form for PHX_CHECK_ORIGIN automatically.
+  # Format: scheme://host or scheme://host:port — no path, query string, or trailing slash.
+  # The chart will derive the host-only form for PHX_CHECK_ORIGIN automatically.
   # Example: ["https://custom.service.internal.company.com"]
   additionalOrigins: []
 


### PR DESCRIPTION
* Renamed `extraEnvs` and `extraSecrets` to `additionalEnvs` and `additionalSecrets` for more standard naming conventions
* Exposed `additionalEnvs` for LaunchControl
* Exposed `additionalSubdomains` and `additionalOrigins` which is needed by us now, others soon