### PR TITLE
Bump chart to 0.1.5 (massdriver 2.2.0, UI 2.0.4)

### DIFF
--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: massdriver
 description: Helm chart for deploying Massdriver
 type: application
-version: 0.1.4
-appVersion: 2.1.2
+version: 0.1.5
+appVersion: 2.2.0
 
 dependencies:
   - name: argo-workflows

--- a/charts/massdriver/values.yaml
+++ b/charts/massdriver/values.yaml
@@ -138,7 +138,7 @@ massdriver:
 
   image:
     repository: massdrivercloud/massdriver
-    tag: "2.1.2"
+    tag: "2.2.0"
 
   port: 4000
 
@@ -344,7 +344,7 @@ ui:
   image:
     repository: massdrivercloud/massdriver-ui
     pullPolicy: IfNotPresent
-    tag: "2.0.3"
+    tag: "2.0.4"
 
   port: 3000
 


### PR DESCRIPTION
## Shipped this week

### Versions
- Helm Chart: `0.1.5`
- Massdriver Server: `2.2.0`
- Massdriver Developer Platform UI: `2.0.4`
- Massdriver Catalog `[preview.yaml](https://github.com/massdriver-cloud/massdriver-catalog/blob/main/preview.yaml)`
- `mass` CLI: `2.1.0`

### Workflows

Environment lifecycle operations are now exposed consistently across the API, CLI, and UI. Each one is idempotent — re-running converges to the same state.

- **Fork Environment** — clone an environment from a parent in the same project. Instances are seeded from the parent's params, version, and release channel. Environment defaults, secrets, and remote-reference overrides are opt-in via `--copy-*` flags. The operation runs as a single transaction, and a fork's parent is immutable.
- **Promote** (`mass instance promote`) — copy instance-level config between environments of the same component. `--overrides` lets you apply env-specific deltas (size, replicas, etc.). The destination lands as a plan deployment, so nothing in the target environment moves until you apply.
- **Preview Environments** — per-PR ephemeral environments driven by a `preview.yaml` file. One CLI call composes fork + environment defaults + per-instance overrides + deploy. GitHub Actions example in the docs.
- **Deploy Environment** — runs a provision deployment across every instance in dependency order. _(docs link TBD)_
- **Decommission Environment** — teardown in reverse dependency order. `--follow` blocks until every instance is gone. _(docs link TBD)_

### Decommission Protection

Environments can be flagged to block decommissioning. The flag is checked at the API layer before any teardown runs, so `decommission` calls against protected environments fail closed.

---

Questions, bug reports, or feedback: drop them here or open an issue.