### PR TITLE
Publish massdriver chart release notes automatically via chart-releaser

### DIFF
--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -1,0 +1,63 @@
+---
+description: Generate public release notes for the massdriver chart into charts/massdriver/RELEASE_NOTES.md
+allowed-tools: Bash(git:*), Read, Write, Glob, Grep
+---
+
+Generate customer-facing release notes for the `massdriver` chart and overwrite
+`charts/massdriver/RELEASE_NOTES.md` with them. chart-releaser publishes this file
+verbatim as the GitHub Release body when the chart version merges to main.
+
+## Gather the diff
+
+1. Read the new chart version from `charts/massdriver/Chart.yaml` (working tree).
+2. Find the last published release of this chart (note the glob excludes
+   `massdriver-alarm-channel-*` and `massdriver-prometheus-rules-*`):
+
+   ```
+   git tag -l 'massdriver-[0-9]*' --sort=-v:refname | head -1
+   ```
+
+   Run `git fetch --tags` first if the tag list looks stale.
+3. Compare `charts/massdriver/values.yaml` and `charts/massdriver/Chart.yaml` at that
+   tag against the working tree. Extract old → new image tags for:
+   - `massdrivercloud/massdriver` (API) — tags in the app repo are bare versions, e.g. `2.4.0`
+   - `massdrivercloud/massdriver-ui` (UI) — tags in the app repo are prefixed, e.g. `web-v2.0.13`
+   Also note chart-level changes: dependency version bumps, removed/added values blocks,
+   template/RBAC changes.
+4. The app repos (`massdriver` and `massdriver-ui`) are sibling directories of the
+   primary helm-charts checkout. From a linked worktree, locate the primary checkout
+   with `git rev-parse --git-common-dir` and look next to it. Run
+   `git -C <repo> fetch --tags`, then for each image whose tag changed:
+
+   ```
+   git -C <repo> log --oneline <old-tag>..<new-tag>
+   ```
+
+   Read individual commits with `git -C <repo> show <sha>` when the one-line subject
+   isn't enough to judge customer impact.
+
+## Write the notes
+
+Overwrite `charts/massdriver/RELEASE_NOTES.md`. The first line MUST be
+`# Massdriver Chart <new chart version>` — the pre-commit hook checks for the version
+on that line. Follow with the app versions, then sections per app and, when relevant,
+chart-level upgrade notes. Match the structure of the previous release's notes
+(`git show <last-release-tag>:charts/massdriver/RELEASE_NOTES.md`) when it exists.
+
+Audience and style — the readers are self-hosted customers, not Massdriver engineers:
+
+- Only include changes a customer can observe: behavior fixes, new features, API/UI
+  changes, deployment topology changes, required values changes.
+- Skip internal refactors, module renames with no API change, test infrastructure,
+  and CI changes entirely. Collapse dependency bumps to a single "Maintenance:
+  dependency updates" line.
+- Use public terminology: "bundles" (not "bundle releases"), "resources" (not
+  "artifacts"). No internal module names.
+- Plain, direct English. Lead each bullet with the user-visible outcome in bold,
+  then one or two sentences of detail.
+- Add an "Upgrade notes" section whenever the chart diff removes or renames values,
+  changes RBAC, or bumps a subchart dependency — state what the operator must do,
+  or that no action is required.
+
+Do not commit — the pre-commit hook (or the operator) stages and commits the file
+with the version bump. Do not modify any other file.

--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -1,11 +1,14 @@
 ---
-description: Generate public release notes for the massdriver chart into charts/massdriver/RELEASE_NOTES.md
-allowed-tools: Bash(git:*), Read, Write, Glob, Grep
+description: Generate public release notes for the massdriver chart (RELEASE_NOTES.md + Artifact Hub changes annotation)
+allowed-tools: Bash(git:*), Read, Write, Edit, Glob, Grep
 ---
 
-Generate customer-facing release notes for the `massdriver` chart and overwrite
-`charts/massdriver/RELEASE_NOTES.md` with them. chart-releaser publishes this file
-verbatim as the GitHub Release body when the chart version merges to main.
+Generate customer-facing release notes for the `massdriver` chart in two places:
+
+1. Overwrite `charts/massdriver/RELEASE_NOTES.md` — chart-releaser publishes this file
+   verbatim as the GitHub Release body when the chart version merges to main.
+2. Replace the `artifacthub.io/changes` annotation in `charts/massdriver/Chart.yaml` —
+   Artifact Hub renders it as the changelog for this chart version.
 
 ## Gather the diff
 
@@ -38,6 +41,8 @@ verbatim as the GitHub Release body when the chart version merges to main.
 
 ## Write the notes
 
+### RELEASE_NOTES.md (GitHub Release body)
+
 Overwrite `charts/massdriver/RELEASE_NOTES.md`. The first line MUST be
 `# Massdriver Chart <new chart version>` — the pre-commit hook checks for the version
 on that line. Follow with the app versions, then sections per app and, when relevant,
@@ -59,5 +64,25 @@ Audience and style — the readers are self-hosted customers, not Massdriver eng
   changes RBAC, or bumps a subchart dependency — state what the operator must do,
   or that no action is required.
 
-Do not commit — the pre-commit hook (or the operator) stages and commits the file
+### artifacthub.io/changes annotation (Artifact Hub changelog)
+
+Replace the entire `artifacthub.io/changes` annotation value in
+`charts/massdriver/Chart.yaml` with this version's changes. Format — a YAML list
+inside the block scalar, one entry per change:
+
+```yaml
+annotations:
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Deactivating a SCIM user now revokes their organization memberships.
+```
+
+- Valid kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
+- Descriptions are plain text one-liners (no markdown) distilled from the same
+  content as RELEASE_NOTES.md — condense multi-sentence bullets to their first
+  sentence. Prefix UI changes with `UI: `.
+- The annotation describes only the version being released; Artifact Hub keeps
+  the history of prior versions itself.
+
+Do not commit — the pre-commit hook (or the operator) stages and commits the files
 with the version bump. Do not modify any other file.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,7 +29,7 @@ if ! command -v claude >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! claude -p "/release-notes" --allowedTools "Bash(git:*),Read,Write,Glob,Grep"; then
+if ! claude -p "/release-notes" --allowedTools "Bash(git:*),Read,Write,Edit,Glob,Grep"; then
   echo "Release notes generation failed. Run 'claude \"/release-notes\"' manually, stage ${notes}, and re-commit." >&2
   exit 1
 fi
@@ -39,5 +39,5 @@ if ! head -1 "$notes" 2>/dev/null | grep -qF "$new_version"; then
   exit 1
 fi
 
-git add "$notes"
-echo "Staged ${notes} for chart ${new_version}."
+git add "$notes" "$chart"
+echo "Staged release notes and Artifact Hub changelog for chart ${new_version}."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+# When a commit bumps the massdriver chart version, make sure
+# charts/massdriver/RELEASE_NOTES.md is regenerated for that version.
+# chart-releaser publishes that file as the GitHub Release body.
+#
+# One-time setup: git config core.hooksPath .githooks
+# Bypass:         git commit --no-verify
+
+chart="charts/massdriver/Chart.yaml"
+notes="charts/massdriver/RELEASE_NOTES.md"
+
+# Nothing staged for the chart manifest? Nothing to do.
+git diff --cached --quiet -- "$chart" && exit 0
+
+new_version=$(git show ":$chart" | awk '/^version:/ {print $2}')
+old_version=$(git show "HEAD:$chart" 2>/dev/null | awk '/^version:/ {print $2}')
+
+[ "$new_version" = "$old_version" ] && exit 0
+
+# Notes already regenerated and staged for this version? Done.
+if git show ":$notes" 2>/dev/null | head -1 | grep -qF "$new_version"; then
+  exit 0
+fi
+
+echo "massdriver chart ${old_version:-<new>} -> ${new_version}: generating release notes (takes a minute)..."
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI not found. Run 'claude \"/release-notes\"', stage ${notes}, and re-commit (or --no-verify)." >&2
+  exit 1
+fi
+
+if ! claude -p "/release-notes" --allowedTools "Bash(git:*),Read,Write,Glob,Grep"; then
+  echo "Release notes generation failed. Run 'claude \"/release-notes\"' manually, stage ${notes}, and re-commit." >&2
+  exit 1
+fi
+
+if ! head -1 "$notes" 2>/dev/null | grep -qF "$new_version"; then
+  echo "${notes} does not lead with version ${new_version}. Fix it, stage it, and re-commit." >&2
+  exit 1
+fi
+
+git add "$notes"
+echo "Staged ${notes} for chart ${new_version}."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,5 +26,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
+        with:
+          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .idea
 .vscode
 .DS_Store
+.claude/worktrees/
 
 Chart.lock

--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ helm delete my-<chart-name>
 ## ArtifactHub
 
 A `gh-pages` branch is managed for publishing helm charts to ArtifactHub.
+
+## Releasing the massdriver chart
+
+Merging a `version:` bump in `charts/massdriver/Chart.yaml` to `main` triggers
+chart-releaser, which tags the release and publishes a GitHub Release using
+`charts/massdriver/RELEASE_NOTES.md` as the body.
+
+One-time setup (per clone) to auto-generate the notes on commit:
+
+```shell
+git config core.hooksPath .githooks
+```
+
+With that in place, committing a chart version bump runs `claude "/release-notes"`,
+which diffs the old and new image tags against the sibling `massdriver` and
+`massdriver-ui` checkouts and regenerates `RELEASE_NOTES.md` for the new version.
+Review the generated notes in the PR — they publish verbatim on merge. To draft
+them manually, run `claude "/release-notes"` yourself; to skip the hook, commit
+with `--no-verify`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ git config core.hooksPath .githooks
 
 With that in place, committing a chart version bump runs `claude "/release-notes"`,
 which diffs the old and new image tags against the sibling `massdriver` and
-`massdriver-ui` checkouts and regenerates `RELEASE_NOTES.md` for the new version.
+`massdriver-ui` checkouts and regenerates `RELEASE_NOTES.md` and the
+`artifacthub.io/changes` annotation (the Artifact Hub changelog) for the new version.
 Review the generated notes in the PR — they publish verbatim on merge. To draft
 them manually, run `claude "/release-notes"` yourself; to skip the hook, commit
 with `--no-verify`.

--- a/charts/massdriver/.helmignore
+++ b/charts/massdriver/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Release notes are published as the GitHub Release body, not packaged
+RELEASE_NOTES.md

--- a/charts/massdriver/Chart.yaml
+++ b/charts/massdriver/Chart.yaml
@@ -5,6 +5,17 @@ type: application
 version: 0.2.0
 appVersion: 2.4.0
 
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: The Launch Control service has been removed. Massdriver now builds and submits provisioning workflows to Argo Workflows directly. The launchControl values block is no longer used.
+    - kind: changed
+      description: The bundled Argo Workflows dependency has been updated from 0.45.14 to 0.47.5.
+    - kind: added
+      description: "UI: the projects list now has a search box for quickly finding projects by name."
+    - kind: added
+      description: "UI: the projects list can now be filtered by the attributes assigned to each project."
+
 dependencies:
   - name: argo-workflows
     condition: argo-workflows.enabled

--- a/charts/massdriver/RELEASE_NOTES.md
+++ b/charts/massdriver/RELEASE_NOTES.md
@@ -1,0 +1,26 @@
+# Massdriver Chart 0.2.0
+
+**Massdriver:** 2.4.0 · **UI:** 2.0.13
+
+## Massdriver 2.4.0
+
+### Changed
+
+- **The Launch Control service has been removed.** Massdriver now builds and submits provisioning workflows to Argo Workflows directly. This removes one deployment, service, and service account from your cluster and eliminates an internal network hop from the deployment path. No configuration changes are required — the chart handles the removal automatically on upgrade.
+
+### Upgrade notes
+
+- The `launchControl` values block is no longer used and can be deleted from your values overrides.
+- The Massdriver service account now holds the Argo Workflows RBAC permissions previously granted to Launch Control.
+- The bundled Argo Workflows dependency has been updated from 0.45.14 to 0.47.5.
+
+## UI 2.0.13
+
+### Added
+
+- **Project search.** The projects list now has a search box for quickly finding projects by name.
+- **Filter projects by attributes.** The projects list can now be filtered by the attributes assigned to each project.
+
+### Maintenance
+
+- Dependency updates.

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,1 @@
+release-notes-file: RELEASE_NOTES.md


### PR DESCRIPTION
Wires customer-facing release notes into the existing chart-releaser flow for the `massdriver` chart.

## How it works

1. Bumping `version:` in `charts/massdriver/Chart.yaml` and committing triggers the new `.githooks/pre-commit` hook, which runs `claude "/release-notes"` and stages the regenerated `charts/massdriver/RELEASE_NOTES.md`.
2. `/release-notes` (new command in `.claude/commands/`) diffs the image tags in `values.yaml` against the last `massdriver-*` release tag, reads `git log old..new` in the sibling `massdriver` / `massdriver-ui` checkouts, and writes public-facing notes for the new version.
3. On merge to `main`, chart-releaser publishes the file verbatim as the GitHub Release body (`release-notes-file: RELEASE_NOTES.md` in the new `cr.yaml`).

The notes are reviewed in the same PR as the version bump, so nothing unreviewed reaches the public release page.

## Setup (one-time, per clone)

```
git config core.hooksPath .githooks
```

Without the hook (or with `--no-verify`), run `claude "/release-notes"` manually before committing a version bump.

## Notes

- `RELEASE_NOTES.md` is seeded with the 0.2.0 notes and added to `.helmignore` so it never ships in the packaged chart.
- Other charts are unaffected — they have no `RELEASE_NOTES.md`, so chart-releaser keeps their default (empty) release body.
- `.claude/worktrees/` added to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)